### PR TITLE
Fix process / memory leackage

### DIFF
--- a/lib/schnueffelstueck/reporter/librato.ex
+++ b/lib/schnueffelstueck/reporter/librato.ex
@@ -27,6 +27,12 @@ defmodule Schnueffelstueck.Reporter.Librato do
     GenServer.start_link(__MODULE__, config, gen_server_options)
   end
 
+  def init(args) do
+    # Prevent process leackage, when the paret process dies, the reporter should also die
+    Process.flag(:trap_exit, true)
+    {:ok, args}
+  end
+
   @doc """
   Reports a list of metrics to Librato.
 


### PR DESCRIPTION
TCP connections are short lived, can come and go at every time, a reporter belongs to a single connection. when the connection dies, the reporter should die as well. so we have trap the exit signal passed.
- trap exit in librato reporter
